### PR TITLE
Nix shell: Use niv from nixpkgs (#2868)

### DIFF
--- a/.github/workflows/niv-updater-rare.yml
+++ b/.github/workflows/niv-updater-rare.yml
@@ -23,7 +23,7 @@ jobs:
         uses: knl/niv-updater-action@60f23607814cf4f2e80a1e32ee74f8323897d09e
         with:
           # might be too noisy
-          whitelist: 'ic-ref,musl-wasi,niv'
+          whitelist: 'ic-ref,musl-wasi'
           labels: |
             automerge-squash
           keep_updating: true

--- a/.github/workflows/niv-updater.yml
+++ b/.github/workflows/niv-updater.yml
@@ -23,7 +23,7 @@ jobs:
         uses: knl/niv-updater-action@60f23607814cf4f2e80a1e32ee74f8323897d09e
         with:
           # might be too noisy
-          blacklist: 'nixpkgs,ic-ref,musl-wasi,niv'
+          blacklist: 'nixpkgs,ic-ref,musl-wasi'
           labels: |
             automerge-squash
           keep_updating: true

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -27,11 +27,6 @@ let
            sources = import sourcesnix { sourcesFile = ./sources.json; pkgs = super; };
         })
 
-        # add a newer version of niv
-        (self: super: {
-           niv = (import self.sources.niv { pkgs = super; }).niv;
-        })
-
         # Selecting the ocaml version
         # (self: super: { ocamlPackages = super.ocamlPackages; })
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -96,19 +96,6 @@
         "url": "https://github.com/WebAssembly/wasi-libc/archive/5ccfab77b097a5d0184f91184952158aa5904c8d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
-    "niv": {
-        "branch": "master",
-        "builtin": false,
-        "description": "Easy dependency management for Nix projects",
-        "homepage": "https://github.com/nmattia/niv",
-        "owner": "nmattia",
-        "repo": "niv",
-        "rev": "65a61b147f307d24bfd0a5cd56ce7d7b7cc61d2e",
-        "sha256": "17mirpsx5wyw262fpsd6n6m47jcgw8k2bwcp1iwdnrlzy4dhcgqh",
-        "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/65a61b147f307d24bfd0a5cd56ce7d7b7cc61d2e.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "nixpkgs": {
         "branch": "release-21.05",
         "builtin": true,


### PR DESCRIPTION
it is up to date enough these days, so a good chance to simplify the
setup.